### PR TITLE
adjust PDN halos

### DIFF
--- a/lambdapdk/freepdk45/libs/fakeram45/apr/openroad/pdngen.tcl
+++ b/lambdapdk/freepdk45/libs/fakeram45/apr/openroad/pdngen.tcl
@@ -3,7 +3,7 @@
 ####################################
 define_pdn_grid -name {fakeram45} -voltage_domains {CORE} -macro \
     -orient {R0 R180 MX MY} \
-    -halo {2.0 2.0 2.0 2.0} \
+    -halo {1.0 1.0 1.0 1.0} \
     -cells {fakeram45_.*}
 add_pdn_stripe -grid {fakeram45} -layer {metal4} -width {0.93} -pitch {10.0} -offset {2}
 add_pdn_stripe -grid {fakeram45} -layer {metal5} -width {0.93} -pitch {10.0} -offset {2}

--- a/lambdapdk/gf180/libs/gf180mcu_fd_ip_sram/apr/openroad/pdngen.tcl
+++ b/lambdapdk/gf180/libs/gf180mcu_fd_ip_sram/apr/openroad/pdngen.tcl
@@ -3,6 +3,6 @@
 ####################################
 define_pdn_grid -name {gf180mcu_fd_ip_sram} -voltage_domains {CORE} -macro \
     -orient {R0 R180 MX MY} \
-    -halo {2.0 2.0 2.0 2.0} \
+    -halo {1.0 1.0 1.0 1.0} \
     -cells {gf180mcu_fd_ip_sram.*}
 add_pdn_connect -grid {gf180mcu_fd_ip_sram} -layers {Metal3 Metal4}

--- a/lambdapdk/sky130/libs/sky130sram/apr/openroad/pdngen.tcl
+++ b/lambdapdk/sky130/libs/sky130sram/apr/openroad/pdngen.tcl
@@ -3,6 +3,6 @@
 ####################################
 define_pdn_grid -name {sky130sram} -voltage_domains {CORE} -macro \
     -orient {R0 R180 MX MY} \
-    -halo {2.0 2.0 2.0 2.0} \
+    -halo {1.0 1.0 1.0 1.0} \
     -cells {sky130_sram_1rw1r_.*}
 add_pdn_connect -grid {sky130sram} -layers {met3 met4}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced PDN halo spacing for several SRAM/IP layouts, allowing power grid placement closer to macros and cells.
  * This may improve floorplan fit and help avoid unnecessary routing overhead in affected designs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->