### PR TITLE
add metal fill decks to the PDKs

### DIFF
--- a/lambdapdk/ihp130/__init__.py
+++ b/lambdapdk/ihp130/__init__.py
@@ -111,6 +111,11 @@ class IHP130PDK(LambdaPDK, _IHP130Path):
                 self.add_file(pdk_path / "pex" / "openroad" / "typical.rules", filetype="openrcx")
                 self.add_pexmodelfileset("openroad", "typical")
 
+            # Metal fill
+            with self.active_fileset("openroad.fill"):
+                self.add_file(pdk_path / "dfm" / "openroad" / "fill.json", filetype="fill")
+                self.add_aprtechfileset("openroad")
+
         # DRC
         drcs = {
             "drc": 'ihp-sg13g2/libs.tech/klayout/tech/drc/ihp-sg13g2.drc',

--- a/lambdapdk/sky130/__init__.py
+++ b/lambdapdk/sky130/__init__.py
@@ -127,6 +127,11 @@ class Sky130PDK(LambdaPDK):
         self.add_openroad_rclayer("maximum", "via", "via4", 0.891)
         self.add_openroad_rclayer("maximum", "routing", "met5", 0.022375, 4.057272E-5 * pF)
         with self.active_dataroot("lambdapdk"):
+            # Metal fill
+            with self.active_fileset("openroad.fill"):
+                self.add_file(pdk_path / "dfm" / "fill.json", filetype="fill")
+                self.add_aprtechfileset("openroad")
+
             for corner in ["minimum", "typical", "maximum"]:
                 with self.active_fileset(f"openroad.pex.{corner}"):
                     self.add_file(pdk_path / "pex" / "openroad" / f"{corner}.rules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">= 3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [
-    "siliconcompiler >= 0.38.0",
+    "siliconcompiler >= 0.38.4",
     "lambdalib >= 0.13.1"
 ]
 dynamic = ['version']


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenROAD metal-fill configuration support for the IHP130 and SKY130 process technologies.
  - Added technology-specific metal-fill data to improve automated layout preparation and fabrication readiness.

- **Improvements**
  - Updated SiliconCompiler compatibility requirements to support the current release.
  - Improved consistency of metal-fill setup across supported process technologies and OpenROAD-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->