### PR TITLE
fix fill registration

### DIFF
--- a/lambdapdk/ihp130/__init__.py
+++ b/lambdapdk/ihp130/__init__.py
@@ -114,7 +114,7 @@ class IHP130PDK(LambdaPDK, _IHP130Path):
             # Metal fill
             with self.active_fileset("openroad.fill"):
                 self.add_file(pdk_path / "dfm" / "openroad" / "fill.json", filetype="fill")
-                self.add_aprtechfileset("openroad")
+                self.add_runsetfileset("fill", "openroad", "beol")
 
         # DRC
         drcs = {

--- a/lambdapdk/interposer/__init__.py
+++ b/lambdapdk/interposer/__init__.py
@@ -77,7 +77,7 @@ class _Interposer(LambdaPDK):
             with self.active_fileset("openroad.fill"):
                 self.add_file(pdk_path / "dfm" / "openroad" / f"{stackup}.fill.json",
                               filetype="fill")
-                self.add_aprtechfileset("openroad")
+                self.add_runsetfileset("fill", "openroad", "beol")
 
             for corner in ["minimum", "typical", "maximum"]:
                 factor = corner_factor[corner]

--- a/lambdapdk/sky130/__init__.py
+++ b/lambdapdk/sky130/__init__.py
@@ -130,7 +130,7 @@ class Sky130PDK(LambdaPDK):
             # Metal fill
             with self.active_fileset("openroad.fill"):
                 self.add_file(pdk_path / "dfm" / "fill.json", filetype="fill")
-                self.add_aprtechfileset("openroad")
+                self.add_runsetfileset("fill", "openroad", "beol")
 
             for corner in ["minimum", "typical", "maximum"]:
                 with self.active_fileset(f"openroad.pex.{corner}"):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenROAD metal-fill configuration across supported technology platforms.
  * Fill runs now use the appropriate back-end-of-line (BEOL) runset, improving compatibility and expected fill behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->