### PR TITLE
fix RST bullet list in GT2N PDK docstring

### DIFF
--- a/lambdapdk/gt2n/__init__.py
+++ b/lambdapdk/gt2n/__init__.py
@@ -24,9 +24,9 @@ class GT2NPDK(LambdaPDK, _GT2NPath):
 
     * https://github.com/azadnaeemi/GT2N/
     * D. Jang, P. Kumar, M. N. H. Shazon, S. J. Ram, A. Svizhenko, V. Moroz, A. Ceyhan,
-    N. A. Radhakrishn, and A. Naeemi, "GT2N: An Open-Source 2nm Nanosheet PDK Enabling
-    Multi-Width/VT Benchmarking," in IEEE International Symposium on Circuits and Systems
-    (ISCAS) 2026.
+      N. A. Radhakrishn, and A. Naeemi, "GT2N: An Open-Source 2nm Nanosheet PDK Enabling
+      Multi-Width/VT Benchmarking," in IEEE International Symposium on Circuits and Systems
+      (ISCAS) 2026.
 
 
     Sources: https://github.com/azadnaeemi/GT2N/


### PR DESCRIPTION
`GT2NPDK`'s docstring continues its citation bullet at the same column as the `*` marker:

```
* https://github.com/azadnaeemi/GT2N/
* D. Jang, P. Kumar, M. N. H. Shazon, S. J. Ram, A. Svizhenko, V. Moroz, A. Ceyhan,
N. A. Radhakrishn, and A. Naeemi, "GT2N: An Open-Source 2nm Nanosheet PDK Enabling
...
```

docutils ends the bullet list at the unindent and warns:

```
WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
```

This fell out of the SiliconCompiler docs build, which renders this docstring on its Pre-Defined PDKs page (siliconcompiler/siliconcompiler#5271 adds the `lambdapdk.gt2n/GT2NPDK` entry) and builds with `fail_on_warning: true`, so the warning fails that build.

Indenting the three continuation lines under the bullet text fixes it and renders the citation as one bullet.

Verified by parsing both versions of the docstring with docutils: `origin/main` reproduces the warning at docstring line 7, the patched version parses with no messages. A scan of every module, class and function docstring in `lambdapdk/` found no other instance of this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of the GT2N PDK citation in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->