### PR TITLE
move target to sc

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,7 @@ project.run()
 project.summary()
 ```
 
-Available targets: `asap7_demo`, `freepdk45_demo`, `skywater130_demo`, `gf180_demo`, `ihp130_demo`, `interposer_demo`
-
-GT2N and ICsprout55 ship their targets in this package instead of SiliconCompiler:
-
-```python
-from lambdapdk.gt2n.target import gt2n_demo
-from lambdapdk.icsprout55.target import ics55_demo
-```
+Available targets: `asap7_demo`, `freepdk45_demo`, `skywater130_demo`, `gf180_demo`, `ihp130_demo`, `interposer_demo`, `gt2n_demo`, and `icsprout55_demo`.
 
 ## Cell Library Inventory
 

--- a/lambdapdk/gt2n/target.py
+++ b/lambdapdk/gt2n/target.py
@@ -1,4 +1,5 @@
 # Import necessary classes from the siliconcompiler framework and the LambdaPDK.
+import warnings
 from typing import Optional
 
 from siliconcompiler import ASIC
@@ -36,6 +37,28 @@ def gt2n_demo(
             * route_np (int): Parallelism for routing.
             * timing_np (int): Parallelism for timing analysis (synthesis-only flow).
         """
+    try:
+        from siliconcompiler.targets import gt2n_demo as sc_gt2n_demo
+    except ImportError:
+        sc_gt2n_demo = None
+
+    if sc_gt2n_demo is not None:
+        warnings.warn(
+            "lambdapdk.gt2n.target.gt2n_demo is deprecated, "
+            "please use siliconcompiler.targets.gt2n_demo instead",
+            DeprecationWarning,
+            stacklevel=2)
+        sc_gt2n_demo(
+            project=project,
+            syn_np=syn_np,
+            floorplan_np=floorplan_np,
+            place_np=place_np,
+            cts_np=cts_np,
+            route_np=route_np,
+            timing_np=timing_np,
+            language=language)
+        return
+
     if language is None:
         language = detect_elaboration_language(project)
 

--- a/lambdapdk/icsprout55/target.py
+++ b/lambdapdk/icsprout55/target.py
@@ -1,4 +1,5 @@
 # Import necessary classes from the siliconcompiler framework and the LambdaPDK.
+import warnings
 from typing import Optional
 
 from siliconcompiler import ASIC
@@ -36,6 +37,28 @@ def ics55_demo(
             * timing_np (int): Parallelism for timing analysis (synthesis-only flow).
             * language (str): Elaboration language, detected from the design if not given.
         """
+    try:
+        from siliconcompiler.targets import icsprout55_demo as sc_ics55_demo
+    except ImportError:
+        sc_ics55_demo = None
+
+    if sc_ics55_demo is not None:
+        warnings.warn(
+            "lambdapdk.icsprout55.target.ics55_demo is deprecated, "
+            "please use siliconcompiler.targets.icsprout55_demo instead",
+            DeprecationWarning,
+            stacklevel=2)
+        sc_ics55_demo(
+            project=project,
+            syn_np=syn_np,
+            floorplan_np=floorplan_np,
+            place_np=place_np,
+            cts_np=cts_np,
+            route_np=route_np,
+            timing_np=timing_np,
+            language=language)
+        return
+
     if language is None:
         language = detect_elaboration_language(project)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility support for the `gt2n_demo` and `ics55_demo` targets.
  * Automatically uses the standard target when available, while preserving local fallback behavior.

* **Documentation**
  * Updated the Quick Start target list to include both demo targets.
  * Simplified setup guidance by removing redundant direct-import examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->