### PR TITLE
update min SC to avoid target bypasses

### DIFF
--- a/lambdapdk/gt2n/target.py
+++ b/lambdapdk/gt2n/target.py
@@ -3,12 +3,7 @@ import warnings
 from typing import Optional
 
 from siliconcompiler import ASIC
-from siliconcompiler.flows import asicflow, synflow
-
-from siliconcompiler.targets._utils import detect_elaboration_language
-
-from lambdapdk.gt2n.libs.stdcells import GT2N6TW31LVT, GT2N6TW31HVT, GT2N6TW31SVT, GT2N6TW31ULVT, \
-    GT2N6TW31ELVT
+from siliconcompiler.targets import gt2n_demo as sc_gt2n_demo
 
 
 ####################################################
@@ -21,12 +16,11 @@ def gt2n_demo(
         timing_np: int = 1,
         language: Optional[str] = None):
     """
-        Configure a siliconcompiler ASIC for the GT2N.
+        Deprecated alias for :func:`siliconcompiler.targets.gt2n_demo`.
 
-        Sets the project's main standard-cell library, configures full ASIC and synthesis-only
-        flows with provided parallelism, selects the "gt2n" PDK, creates slow/typical/fast STA
-        scenarios, sets the ASIC delay model to "nldm", applies core area density and margin
-        constraints.
+        The GT2N target now ships with siliconcompiler; this wrapper forwards every argument
+        unchanged and will be removed in a future release. Import the target from
+        ``siliconcompiler.targets`` instead.
 
         Parameters:
             * project (ASIC): The siliconcompiler project to configure.
@@ -36,76 +30,19 @@ def gt2n_demo(
             * cts_np (int): Parallelism for clock-tree synthesis.
             * route_np (int): Parallelism for routing.
             * timing_np (int): Parallelism for timing analysis (synthesis-only flow).
+            * language (str): Elaboration language, detected from the design if not given.
         """
-    try:
-        from siliconcompiler.targets import gt2n_demo as sc_gt2n_demo
-    except ImportError:
-        sc_gt2n_demo = None
-
-    if sc_gt2n_demo is not None:
-        warnings.warn(
-            "lambdapdk.gt2n.target.gt2n_demo is deprecated, "
-            "please use siliconcompiler.targets.gt2n_demo instead",
-            DeprecationWarning,
-            stacklevel=2)
-        sc_gt2n_demo(
-            project=project,
-            syn_np=syn_np,
-            floorplan_np=floorplan_np,
-            place_np=place_np,
-            cts_np=cts_np,
-            route_np=route_np,
-            timing_np=timing_np,
-            language=language)
-        return
-
-    if language is None:
-        language = detect_elaboration_language(project)
-
-    # 1. Load Standard Cell Library
-    # Sets the primary standard cell library for the design. This library
-    # contains the basic building blocks (gates, flip-flops) for synthesis.
-    main = GT2N6TW31SVT()
-    project.set_mainlib(main)
-    for lib in [main, GT2N6TW31HVT(), GT2N6TW31LVT(), GT2N6TW31ULVT(), GT2N6TW31ELVT()]:
-        project.add_asiclib(lib)
-
-    # 2. Configure Compilation Flows
-    # Defines the sequence of steps (tools) for the complete ASIC design flow
-    # from synthesis to GDSII. Also adds a separate synthesis-only flow.
-    project.set_flow(asicflow.ASICFlow(
+    warnings.warn(
+        "lambdapdk.gt2n.target.gt2n_demo is deprecated, "
+        "please use siliconcompiler.targets.gt2n_demo instead",
+        DeprecationWarning,
+        stacklevel=2)
+    sc_gt2n_demo(
+        project=project,
         syn_np=syn_np,
         floorplan_np=floorplan_np,
         place_np=place_np,
         cts_np=cts_np,
         route_np=route_np,
-        language=language))
-    project.add_dep(synflow.SynthesisFlow(
-        syn_np=syn_np,
         timing_np=timing_np,
-        language=language))
-
-    # 3. Set Target PDK
-    # Specifies the process development kit to be used.
-    project.set_pdk("gt2n")
-
-    # 4. Define Timing Corners for Static Timing Analysis (STA)
-    # Sets up different scenarios to analyze timing performance under various
-    # process, voltage, and temperature (PVT) conditions.
-
-    # Typical corner: Used for power analysis under nominal conditions.
-    scenario = project.constraint.timing.make_scenario("typical")
-    scenario.add_libcorner("typical")
-    scenario.set_pexcorner("typical")
-    scenario.add_check(["setup", "hold", "power"])
-
-    # Set the delay model used for timing calculations. NLDM is a common standard.
-    project.set_asic_delaymodel("nldm")
-
-    # 5. Define Physical Design Constraints
-    # These constraints guide the place-and-route tools.
-    area = project.constraint.area
-    # Target a core utilization of 40%.
-    area.set_density(40)
-    # Set a margin of 4.8 microns around the core area.
-    area.set_coremargin(1.0)
+        language=language)

--- a/lambdapdk/icsprout55/target.py
+++ b/lambdapdk/icsprout55/target.py
@@ -3,11 +3,7 @@ import warnings
 from typing import Optional
 
 from siliconcompiler import ASIC
-from siliconcompiler.flows import asicflow, synflow
-
-from siliconcompiler.targets._utils import detect_elaboration_language
-
-from lambdapdk.icsprout55.libs.stdcells import ICS55StdCellRVT, ICS55StdCellHVT, ICS55StdCellLVT
+from siliconcompiler.targets import icsprout55_demo as sc_ics55_demo
 
 
 ####################################################
@@ -20,12 +16,11 @@ def ics55_demo(
         timing_np: int = 1,
         language: Optional[str] = None):
     """
-        Configure a siliconcompiler ASIC for the ICsprout 55nm PDK.
+        Deprecated alias for :func:`siliconcompiler.targets.icsprout55_demo`.
 
-        Sets the project's main standard-cell library, configures full ASIC and synthesis-only
-        flows with provided parallelism, selects the "icsprout55" PDK, creates slow/typical/fast
-        STA scenarios, sets the ASIC delay model to "nldm", and applies core area density and
-        margin constraints.
+        The ICsprout 55nm target now ships with siliconcompiler; this wrapper forwards every
+        argument unchanged and will be removed in a future release. Import the target from
+        ``siliconcompiler.targets`` instead.
 
         Parameters:
             * project (ASIC): The siliconcompiler project to configure.
@@ -37,90 +32,17 @@ def ics55_demo(
             * timing_np (int): Parallelism for timing analysis (synthesis-only flow).
             * language (str): Elaboration language, detected from the design if not given.
         """
-    try:
-        from siliconcompiler.targets import icsprout55_demo as sc_ics55_demo
-    except ImportError:
-        sc_ics55_demo = None
-
-    if sc_ics55_demo is not None:
-        warnings.warn(
-            "lambdapdk.icsprout55.target.ics55_demo is deprecated, "
-            "please use siliconcompiler.targets.icsprout55_demo instead",
-            DeprecationWarning,
-            stacklevel=2)
-        sc_ics55_demo(
-            project=project,
-            syn_np=syn_np,
-            floorplan_np=floorplan_np,
-            place_np=place_np,
-            cts_np=cts_np,
-            route_np=route_np,
-            timing_np=timing_np,
-            language=language)
-        return
-
-    if language is None:
-        language = detect_elaboration_language(project)
-
-    # 1. Load Standard Cell Library
-    # Sets the primary standard cell library for the design. This library
-    # contains the basic building blocks (gates, flip-flops) for synthesis.
-    # The three Vt flavors ship the same 747 cells; the regular Vt library is the
-    # default. The Verilog models of the three declare the same UDP primitive names,
-    # so a multi-Vt netlist cannot be compiled for gate-level simulation.
-    project.set_mainlib(ICS55StdCellRVT())
-    project.add_asiclib(ICS55StdCellRVT())
-    project.add_asiclib(ICS55StdCellHVT())
-    project.add_asiclib(ICS55StdCellLVT())
-
-    # 2. Configure Compilation Flows
-    # Defines the sequence of steps (tools) for the complete ASIC design flow
-    # from synthesis to GDSII. Also adds a separate synthesis-only flow.
-    project.set_flow(asicflow.ASICFlow(
+    warnings.warn(
+        "lambdapdk.icsprout55.target.ics55_demo is deprecated, "
+        "please use siliconcompiler.targets.icsprout55_demo instead",
+        DeprecationWarning,
+        stacklevel=2)
+    sc_ics55_demo(
+        project=project,
         syn_np=syn_np,
         floorplan_np=floorplan_np,
         place_np=place_np,
         cts_np=cts_np,
         route_np=route_np,
-        language=language))
-    project.add_dep(synflow.SynthesisFlow(
-        syn_np=syn_np,
         timing_np=timing_np,
-        language=language))
-
-    # 3. Set Target PDK
-    # Specifies the process development kit to be used.
-    project.set_pdk("icsprout55")
-
-    # 4. Define Timing Corners for Static Timing Analysis (STA)
-    # Sets up different scenarios to analyze timing performance under various
-    # process, voltage, and temperature (PVT) conditions.
-
-    # Slow corner: Checks for setup time violations at worst-case conditions.
-    scenario = project.constraint.timing.make_scenario("slow")
-    scenario.add_libcorner("slow")
-    scenario.set_pexcorner("typical")
-    scenario.add_check("setup")
-
-    # Typical corner: Used for power analysis under nominal conditions.
-    scenario = project.constraint.timing.make_scenario("typical")
-    scenario.add_libcorner("typical")
-    scenario.set_pexcorner("typical")
-    scenario.add_check("power")
-
-    # Fast corner: Checks for hold time violations at best-case conditions.
-    scenario = project.constraint.timing.make_scenario("fast")
-    scenario.add_libcorner("fast")
-    scenario.set_pexcorner("typical")
-    scenario.add_check("hold")
-
-    # Set the delay model used for timing calculations. NLDM is a common standard.
-    project.set_asic_delaymodel("nldm")
-
-    # 5. Define Physical Design Constraints
-    # These constraints guide the place-and-route tools.
-    area = project.constraint.area
-    # Target a core utilization of 40%.
-    area.set_density(40)
-    # Set a margin around the core area, a whole number of 1.4um rows.
-    area.set_coremargin(4.2)
+        language=language)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">= 3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [
-    "siliconcompiler >= 0.38.4",
+    "siliconcompiler >= 0.38.5",
     "lambdalib >= 0.13.1"
 ]
 dynamic = ['version']


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation**
  * Legacy GT2N and IC Sprout55 demo targets now forward to SiliconCompiler’s built-in targets.
  * Deprecation warnings are shown when these legacy targets are used.

* **Compatibility**
  * Updated the minimum supported SiliconCompiler version to 0.38.5.
  * Existing target arguments and behavior continue to be forwarded to the built-in implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->