### PR TITLE
add power grids for 30K

### DIFF
--- a/lambdapdk/__init__.py
+++ b/lambdapdk/__init__.py
@@ -270,6 +270,10 @@ def get_libs():
         GF180Lambdalib_la_iorxdiff_5LM, \
         GF180Lambdalib_la_iobidir_5LM
     from lambdapdk.gf180.libs.gf180mcu import GF180_MCU_7T_3LMLibrary, \
+        GF180_MCU_7T_3LM_30KLibrary, \
+        GF180_MCU_7T_4LM_30KLibrary, \
+        GF180_MCU_9T_3LM_30KLibrary, \
+        GF180_MCU_9T_4LM_30KLibrary, \
         GF180_MCU_7T_4LMLibrary, \
         GF180_MCU_7T_5LMLibrary, \
         GF180_MCU_7T_6LMLibrary, \
@@ -386,6 +390,10 @@ def get_libs():
         ICS55StdCellHVT(), ICS55StdCellRVT(), ICS55StdCellLVT(),
         GF180_IO_3LM(), GF180_IO_4LM(), GF180_IO_5LM(),
         GF180_MCU_7T_3LMLibrary(),
+        GF180_MCU_7T_3LM_30KLibrary(),
+        GF180_MCU_7T_4LM_30KLibrary(),
+        GF180_MCU_9T_3LM_30KLibrary(),
+        GF180_MCU_9T_4LM_30KLibrary(),
         GF180_MCU_7T_4LMLibrary(),
         GF180_MCU_7T_5LMLibrary(),
         GF180_MCU_7T_6LMLibrary(),

--- a/lambdapdk/gf180/__init__.py
+++ b/lambdapdk/gf180/__init__.py
@@ -254,6 +254,11 @@ class _GF180PDK(LambdaPDK):
         # with 'GRT-0005 Layer Metal6 not found' on the 6LM variants.
         top_layer = "MetalTop" if max_layer == 6 else f"Metal{max_layer}"
 
+        # The 30K thickness option gives the top metal a 2.2um minimum width,
+        # which changes both what the power grid may draw on it and whether the
+        # router can use it at all. Only 3LM and 4LM ship a 30K option.
+        thick_top = stackup.endswith("_30K")
+
         with self.active_dataroot("lambdapdk"):
             # APR Setup
             with self.active_fileset("views.lef"):
@@ -337,7 +342,22 @@ class _GF180PDK(LambdaPDK):
             self.set_aprroutinglayers(min="Metal2", max="Metal3")
         elif max_layer == 4:
             self.set_openroad_rclayers(signal="Metal2", clock="Metal3")
-            self.add_openroad_pinlayers(vertical="Metal4", horizontal="Metal3")
+            if thick_top:
+                # The 30K option's top metal is a 2.2um-minimum-width power/RDL
+                # layer, not a signal layer. OpenROAD cannot build a legal
+                # single-cut via up to it -- the enclosure rule yields a 0.50um
+                # landing pad against a 2.2um minimum width, so detailed routing
+                # fails with 'DRT-0234 Via3 does not have single-cut via' -- and
+                # a signal wire there would be 2.2um wide on a 4.0um pitch,
+                # carrying almost no routing capacity for the trouble. Stop
+                # signals below it and leave it to the power grid, which is what
+                # its width suits it for. Pin layers follow the routing down;
+                # directions are the tech LEF's (Metal2 vertical, Metal3
+                # horizontal).
+                self.set_aprroutinglayers(min="Metal1", max="Metal3")
+                self.add_openroad_pinlayers(vertical="Metal2", horizontal="Metal3")
+            else:
+                self.add_openroad_pinlayers(vertical="Metal4", horizontal="Metal3")
         elif max_layer >= 5:
             self.set_openroad_rclayers(signal="Metal3", clock="Metal4")
             self.add_openroad_pinlayers(vertical="Metal4", horizontal="Metal3")

--- a/lambdapdk/gf180/libs/gf180mcu.py
+++ b/lambdapdk/gf180/libs/gf180mcu.py
@@ -29,22 +29,40 @@ class _GF180_MCULibrary(LambdaLibrary):
     '''
     GF180 standard cell library.
     '''
-    def __init__(self, libtype, stackup):
+    def __init__(self, libtype, stackup, thickness=None):
+        """
+        Args:
+            libtype (str): cell height, '7t' or '9t'.
+            stackup (str): routing layer count, '3LM' through '6LM'.
+            thickness (str, optional): top-metal thickness option, when this
+                library is specific to one. Only '30K' is used: its top metal
+                has a 2.2um minimum width, so it needs its own power grid
+                rather than the 1.6um stripe the thinner options share.
+        """
         super().__init__()
-        self.set_name(f"gf180mcu_fd_sc_mcu{libtype}5v0_{stackup}")
+        name = f"gf180mcu_fd_sc_mcu{libtype}5v0_{stackup}"
+        if thickness:
+            if stackup not in ("3LM", "4LM"):
+                raise ValueError(f"{stackup} ships no {thickness} option")
+            name += f"_{thickness}"
+        self.set_name(name)
 
         pdn_stackup = stackup
         if libtype == "7t":
             if stackup == "3LM":
-                self.add_asic_pdk(GF180_3LM_1TM_6K_7t(), default=False)
-                self.add_asic_pdk(GF180_3LM_1TM_9K_7t(), default=False)
-                self.add_asic_pdk(GF180_3LM_1TM_11K_7t(), default=False)
-                self.add_asic_pdk(GF180_3LM_1TM_30K_7t(), default=False)
+                if thickness == "30K":
+                    self.add_asic_pdk(GF180_3LM_1TM_30K_7t())
+                else:
+                    self.add_asic_pdk(GF180_3LM_1TM_6K_7t(), default=False)
+                    self.add_asic_pdk(GF180_3LM_1TM_9K_7t(), default=False)
+                    self.add_asic_pdk(GF180_3LM_1TM_11K_7t(), default=False)
             elif stackup == "4LM":
-                self.add_asic_pdk(GF180_4LM_1TM_6K_7t(), default=False)
-                self.add_asic_pdk(GF180_4LM_1TM_9K_7t(), default=False)
-                self.add_asic_pdk(GF180_4LM_1TM_11K_7t(), default=False)
-                self.add_asic_pdk(GF180_4LM_1TM_30K_7t(), default=False)
+                if thickness == "30K":
+                    self.add_asic_pdk(GF180_4LM_1TM_30K_7t())
+                else:
+                    self.add_asic_pdk(GF180_4LM_1TM_6K_7t(), default=False)
+                    self.add_asic_pdk(GF180_4LM_1TM_9K_7t(), default=False)
+                    self.add_asic_pdk(GF180_4LM_1TM_11K_7t(), default=False)
             elif stackup == "5LM":
                 self.add_asic_pdk(GF180_5LM_1TM_9K_7t(), default=False)
                 self.add_asic_pdk(GF180_5LM_1TM_11K_7t(), default=False)
@@ -57,15 +75,19 @@ class _GF180_MCULibrary(LambdaLibrary):
             self.add_asic_site("GF018hv5v_mcu_sc7")
         elif libtype == "9t":
             if stackup == "3LM":
-                self.add_asic_pdk(GF180_3LM_1TM_6K_9t(), default=False)
-                self.add_asic_pdk(GF180_3LM_1TM_9K_9t(), default=False)
-                self.add_asic_pdk(GF180_3LM_1TM_11K_9t(), default=False)
-                self.add_asic_pdk(GF180_3LM_1TM_30K_9t(), default=False)
+                if thickness == "30K":
+                    self.add_asic_pdk(GF180_3LM_1TM_30K_9t())
+                else:
+                    self.add_asic_pdk(GF180_3LM_1TM_6K_9t(), default=False)
+                    self.add_asic_pdk(GF180_3LM_1TM_9K_9t(), default=False)
+                    self.add_asic_pdk(GF180_3LM_1TM_11K_9t(), default=False)
             elif stackup == "4LM":
-                self.add_asic_pdk(GF180_4LM_1TM_6K_9t(), default=False)
-                self.add_asic_pdk(GF180_4LM_1TM_9K_9t(), default=False)
-                self.add_asic_pdk(GF180_4LM_1TM_11K_9t(), default=False)
-                self.add_asic_pdk(GF180_4LM_1TM_30K_9t(), default=False)
+                if thickness == "30K":
+                    self.add_asic_pdk(GF180_4LM_1TM_30K_9t())
+                else:
+                    self.add_asic_pdk(GF180_4LM_1TM_6K_9t(), default=False)
+                    self.add_asic_pdk(GF180_4LM_1TM_9K_9t(), default=False)
+                    self.add_asic_pdk(GF180_4LM_1TM_11K_9t(), default=False)
             elif stackup == "5LM":
                 self.add_asic_pdk(GF180_5LM_1TM_9K_9t(), default=False)
                 self.add_asic_pdk(GF180_5LM_1TM_11K_9t(), default=False)
@@ -160,7 +182,10 @@ class _GF180_MCULibrary(LambdaLibrary):
         # Setup for OpenROAD
         with self.active_dataroot("lambdapdk"):
             with self.active_fileset("openroad.powergrid"):
-                self.add_file(lib_path / "apr" / "openroad" / f"pdngen_{pdn_stackup}.tcl")
+                pdn_name = pdn_stackup
+                if thickness:
+                    pdn_name += f"_{thickness}"
+                self.add_file(lib_path / "apr" / "openroad" / f"pdngen_{pdn_name}.tcl")
                 self.add_openroad_powergridfileset()
             with self.active_fileset("openroad.globalconnect"):
                 self.add_file(lib_path / "apr" / "openroad" / "global_connect.tcl")
@@ -181,9 +206,23 @@ class GF180_MCU_7T_3LMLibrary(_GF180_MCULibrary):
         super().__init__("7t", "3LM")
 
 
+class GF180_MCU_7T_3LM_30KLibrary(_GF180_MCULibrary):
+    """3LM 7t paired with the 30K top metal, whose 2.2um minimum width the
+    shared 1.6um power stripe violates."""
+    def __init__(self):
+        super().__init__("7t", "3LM", thickness="30K")
+
+
 class GF180_MCU_7T_4LMLibrary(_GF180_MCULibrary):
     def __init__(self):
         super().__init__("7t", "4LM")
+
+
+class GF180_MCU_7T_4LM_30KLibrary(_GF180_MCULibrary):
+    """4LM 7t paired with the 30K top metal, whose 2.2um minimum width the
+    shared 1.6um power stripe violates."""
+    def __init__(self):
+        super().__init__("7t", "4LM", thickness="30K")
 
 
 class GF180_MCU_7T_5LMLibrary(_GF180_MCULibrary):
@@ -201,9 +240,23 @@ class GF180_MCU_9T_3LMLibrary(_GF180_MCULibrary):
         super().__init__("9t", "3LM")
 
 
+class GF180_MCU_9T_3LM_30KLibrary(_GF180_MCULibrary):
+    """3LM 9t paired with the 30K top metal, whose 2.2um minimum width the
+    shared 1.6um power stripe violates."""
+    def __init__(self):
+        super().__init__("9t", "3LM", thickness="30K")
+
+
 class GF180_MCU_9T_4LMLibrary(_GF180_MCULibrary):
     def __init__(self):
         super().__init__("9t", "4LM")
+
+
+class GF180_MCU_9T_4LM_30KLibrary(_GF180_MCULibrary):
+    """4LM 9t paired with the 30K top metal, whose 2.2um minimum width the
+    shared 1.6um power stripe violates."""
+    def __init__(self):
+        super().__init__("9t", "4LM", thickness="30K")
 
 
 class GF180_MCU_9T_5LMLibrary(_GF180_MCULibrary):

--- a/lambdapdk/gf180/libs/gf180mcu_fd_sc_mcu7t5v0/apr/openroad/pdngen_3LM_30K.tcl
+++ b/lambdapdk/gf180/libs/gf180mcu_fd_sc_mcu7t5v0/apr/openroad/pdngen_3LM_30K.tcl
@@ -1,0 +1,35 @@
+####################################
+# voltage domains
+####################################
+set_voltage_domain -name {CORE} -power {VDD} -ground {VSS}
+####################################
+# standard cell grid
+####################################
+define_pdn_grid -name {grid} -voltage_domains {CORE} -pins {Metal3}
+add_pdn_stripe -grid {grid} -layer {Metal1} -width {0.600} -pitch {3.92} -offset {0} -followpins
+
+set metal2_pitch [expr {([lindex [ord::get_core_area] 2] - [lindex [ord::get_core_area] 0]) / 2}]
+if {$metal2_pitch > 44.8} {
+    set metal2_pitch 44.8
+}
+set metal3_pitch [expr {([lindex [ord::get_core_area] 3] - [lindex [ord::get_core_area] 1]) / 2}]
+if {$metal3_pitch > 89.6} {
+    set metal3_pitch 89.6
+}
+
+proc snap_grid {value} {
+    set grid [[ord::get_db_tech] getManufacturingGrid]
+    set dbus [[ord::get_db_tech] getDbUnitsPerMicron]
+
+    set val_dbus [ord::microns_to_dbu $value]
+    set val_snapped [expr {$grid * round($val_dbus / $grid)}]
+
+    return [ord::dbu_to_microns $val_snapped]
+}
+
+add_pdn_stripe -grid {grid} -layer {Metal2} -width {1.600} -pitch [snap_grid $metal2_pitch] \
+    -offset [snap_grid [expr {$metal2_pitch / 4}]]
+add_pdn_stripe -grid {grid} -layer {Metal3} -width {2.200} -pitch [snap_grid $metal3_pitch] \
+    -offset [snap_grid [expr {$metal3_pitch / 4}]]
+add_pdn_connect -grid {grid} -layers {Metal1 Metal2}
+add_pdn_connect -grid {grid} -layers {Metal2 Metal3}

--- a/lambdapdk/gf180/libs/gf180mcu_fd_sc_mcu7t5v0/apr/openroad/pdngen_4LM_30K.tcl
+++ b/lambdapdk/gf180/libs/gf180mcu_fd_sc_mcu7t5v0/apr/openroad/pdngen_4LM_30K.tcl
@@ -1,0 +1,28 @@
+####################################
+# voltage domains
+####################################
+set_voltage_domain -name {CORE} -power {VDD} -ground {VSS}
+####################################
+# standard cell grid
+####################################
+define_pdn_grid -name {grid} -voltage_domains {CORE} -pins {Metal4}
+add_pdn_stripe -grid {grid} -layer {Metal1} -width {0.600} -pitch {3.92} -offset {0} -followpins
+
+set metal4_pitch [expr {([lindex [ord::get_core_area] 2] - [lindex [ord::get_core_area] 0]) / 2}]
+if {$metal4_pitch > 44.8} {
+    set metal4_pitch 44.8
+}
+
+proc snap_grid {value} {
+    set grid [[ord::get_db_tech] getManufacturingGrid]
+    set dbus [[ord::get_db_tech] getDbUnitsPerMicron]
+
+    set val_dbus [ord::microns_to_dbu $value]
+    set val_snapped [expr {$grid * round($val_dbus / $grid)}]
+
+    return [ord::dbu_to_microns $val_snapped]
+}
+
+add_pdn_stripe -grid {grid} -layer {Metal4} -width {2.200} -pitch [snap_grid $metal4_pitch] \
+    -offset [snap_grid [expr {$metal4_pitch / 4}]]
+add_pdn_connect -grid {grid} -layers {Metal1 Metal4}

--- a/lambdapdk/gf180/libs/gf180mcu_fd_sc_mcu9t5v0/apr/openroad/pdngen_3LM_30K.tcl
+++ b/lambdapdk/gf180/libs/gf180mcu_fd_sc_mcu9t5v0/apr/openroad/pdngen_3LM_30K.tcl
@@ -1,0 +1,28 @@
+####################################
+# voltage domains
+####################################
+set_voltage_domain -name {CORE} -power {VDD} -ground {VSS}
+####################################
+# standard cell grid
+####################################
+define_pdn_grid -name {grid} -voltage_domains {CORE} -pins {Metal3}
+add_pdn_stripe -grid {grid} -layer {Metal1} -width {0.900} -pitch {5.040} -offset {0} -followpins
+
+set metal3_pitch [expr {([lindex [ord::get_core_area] 3] - [lindex [ord::get_core_area] 1]) / 2}]
+if {$metal3_pitch > 89.6} {
+    set metal3_pitch 89.6
+}
+
+proc snap_grid {value} {
+    set grid [[ord::get_db_tech] getManufacturingGrid]
+    set dbus [[ord::get_db_tech] getDbUnitsPerMicron]
+
+    set val_dbus [ord::microns_to_dbu $value]
+    set val_snapped [expr {$grid * round($val_dbus / $grid)}]
+
+    return [ord::dbu_to_microns $val_snapped]
+}
+
+add_pdn_stripe -grid {grid} -layer {Metal3} -width {2.200} -pitch [snap_grid $metal3_pitch] \
+    -offset [snap_grid [expr {$metal3_pitch / 4}]]
+add_pdn_connect -grid {grid} -layers {Metal1 Metal3}

--- a/lambdapdk/gf180/libs/gf180mcu_fd_sc_mcu9t5v0/apr/openroad/pdngen_4LM_30K.tcl
+++ b/lambdapdk/gf180/libs/gf180mcu_fd_sc_mcu9t5v0/apr/openroad/pdngen_4LM_30K.tcl
@@ -1,0 +1,28 @@
+####################################
+# voltage domains
+####################################
+set_voltage_domain -name {CORE} -power {VDD} -ground {VSS}
+####################################
+# standard cell grid
+####################################
+define_pdn_grid -name {grid} -voltage_domains {CORE} -pins {Metal4}
+add_pdn_stripe -grid {grid} -layer {Metal1} -width {0.900} -pitch {5.040} -offset {0} -followpins
+
+set metal4_pitch [expr {([lindex [ord::get_core_area] 2] - [lindex [ord::get_core_area] 0]) / 2}]
+if {$metal4_pitch > 44.8} {
+    set metal4_pitch 44.8
+}
+
+proc snap_grid {value} {
+    set grid [[ord::get_db_tech] getManufacturingGrid]
+    set dbus [[ord::get_db_tech] getDbUnitsPerMicron]
+
+    set val_dbus [ord::microns_to_dbu $value]
+    set val_snapped [expr {$grid * round($val_dbus / $grid)}]
+
+    return [ord::dbu_to_microns $val_snapped]
+}
+
+add_pdn_stripe -grid {grid} -layer {Metal4} -width {2.200} -pitch [snap_grid $metal4_pitch] \
+    -offset [snap_grid [expr {$metal4_pitch / 4}]]
+add_pdn_connect -grid {grid} -layers {Metal1 Metal4}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GF180 MCU 30K variants across 3-layer and 4-layer metal stackups.
  * Added four 30K standard-cell library options for 7T and 9T configurations.
  * Added OpenROAD power-distribution configurations for all supported 30K variants.
  * Added automatic manufacturing-grid alignment for power-grid dimensions.
  * Updated routing and pin-layer settings for 30K configurations.

* **Bug Fixes**
  * Invalid thickness and stackup combinations now produce a clear validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->