### PR TITLE
Added RTL fileset to asap7

### DIFF
--- a/lambdapdk/asap7/libs/asap7sc7p5t.py
+++ b/lambdapdk/asap7/libs/asap7sc7p5t.py
@@ -75,6 +75,11 @@ class _ASAP7SC7p5Base(LambdaLibrary):
                 self.add_file(lib_path / "netlist" / f"asap7sc7p5t_28_{suffix}.cdl")
                 self.add_asic_aprfileset()
 
+            with self.active_fileset("rtl"):
+                for lib_type in ('AO', 'INVBUF', 'OA', 'SEQ', 'SIMPLE'):
+                    self.add_file(lib_path / "verilog" /
+                                  f"asap7sc7p5t_{lib_type}_{suffix}VT_TT.v")
+
         # Setup for yosys
         with self.active_dataroot("lambdapdk"):
             self.set_yosys_driver_cell(f"BUFx2_ASAP7_75t_{suffix}")


### PR DESCRIPTION
Needed for doing GLS with asap7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RTL model support for the ASAP7 7.5-track library.
  - Included TT Verilog models for AO, INVBUF, OA, SEQ, and SIMPLE cell types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->