### PR TITLE
Switched to using models.sim for stdcell verilog models

### DIFF
--- a/lambdapdk/asap7/libs/asap7sc7p5t.py
+++ b/lambdapdk/asap7/libs/asap7sc7p5t.py
@@ -75,6 +75,11 @@ class _ASAP7SC7p5Base(LambdaLibrary):
                 self.add_file(lib_path / "netlist" / f"asap7sc7p5t_28_{suffix}.cdl")
                 self.add_asic_aprfileset()
 
+            with self.active_fileset("models.sim"):
+                for lib_type in ('AO', 'INVBUF', 'OA', 'SEQ', 'SIMPLE'):
+                    self.add_file(lib_path / "verilog" /
+                                  f"asap7sc7p5t_{lib_type}_{suffix}VT_TT.v")
+
         # Setup for yosys
         with self.active_dataroot("lambdapdk"):
             self.set_yosys_driver_cell(f"BUFx2_ASAP7_75t_{suffix}")

--- a/lambdapdk/ihp130/libs/sg13g2_stdcell.py
+++ b/lambdapdk/ihp130/libs/sg13g2_stdcell.py
@@ -49,7 +49,7 @@ class _IHP130StdCell(LambdaLibrary, _IHP130Path):
                 self.add_file("ihp-sg13g2/libs.ref/sg13g2_stdcell/cdl/sg13g2_stdcell.cdl")
                 self.add_asic_aprfileset()
 
-            with self.active_fileset("rtl"):
+            with self.active_fileset("models.sim"):
                 self.add_file("ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.v")
                 self.add_asic_aprfileset()
 

--- a/lambdapdk/sky130/libs/sky130sc.py
+++ b/lambdapdk/sky130/libs/sky130sc.py
@@ -39,7 +39,7 @@ class _Sky130_SCLibrary(LambdaLibrary):
                 self.add_file(lib_path / "cdl" / f"sky130_fd_sc_{libtype}.cdl")
                 self.add_asic_aprfileset()
 
-            with self.active_fileset("rtl"):
+            with self.active_fileset("models.sim"):
                 self.add_file(lib_path / "verilog" / f"sky130_fd_sc_{libtype}.v")
                 self.add_file(lib_path / "verilog" / "primitives.v")
 


### PR DESCRIPTION
Also added RTL models to asap7 for GLS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Verilog simulation models for ASAP7 7.5-track standard-cell libraries.
  * Standard-cell Verilog models for IHP130 and Sky130 are now available through the simulation fileset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->